### PR TITLE
Fix for issue #22. Graph data displays correctly after system failure.

### DIFF
--- a/src/CSVConvertGraphs.py
+++ b/src/CSVConvertGraphs.py
@@ -11,19 +11,38 @@ sys_config = "src/ParkitConfiguration.xml"
 def read_csv(filename):
     log(f"Reading CSV File: {filename}")  # Print out the filename
     data = []
+    skip = False
+    skip_count = 0
+
     with open(filename, 'r') as file:
         reader = csv.reader(file)
         next(reader)  # Skip header
+        # Skip the line with "### SYSTEM RESTART ###" and 3 lines after.
         for row in reader:
+            if skip:
+                if skip_count < 4:
+                    skip_count += 1
+                    continue  
+                else:
+                    skip = False
+                    skip_count = 0
+
+            if row[0] == "### SYSTEM RESTART ###":
+                skip = True 
+                continue  
+
             if row[0].startswith("#"):
-                continue
+                continue 
+
             status_car = row[1] == 'CAR IN SPACE'
             time = datetime.strptime(row[2], '%Y-%m-%d %H:%M:%S')
             rectangle_x = float(row[3])
             rectangle_y = float(row[4])
             rectangle_width = float(row[5])
             rectangle_height = float(row[6])
+
             data.append((status_car, time, rectangle_x, rectangle_y, rectangle_width, rectangle_height))
+
     return data
 
 # Function to plot graph and save it to a PNG file

--- a/src/ObjectOccupancyDetector.py
+++ b/src/ObjectOccupancyDetector.py
@@ -71,12 +71,16 @@ rect = [rectx, recty, rectw, recth]
 # Load a pre-trained YOLOv5 model on the application server CPU
 yolov5_model = YOLOv5(weights, device=resource)  
 
+
+data_output_fd = get_value_from_tag(sys_config, "system-output-location")
+csv_file_location = get_value_from_tag(sys_config, "csv-file-location")
+
 # Reference frame used when checking occupancy
 # Use previously loaded reference frame if the status is marked as failed
-
 reference_frame = None
 if get_value_from_tag(sys_config, "status") == "failed":
     reference_frame = np.load(prev_saved_rframe)
+    append_text_to_file(csv_file_location, "### SYSTEM RESTART ###")
     log(f"Previous reference frame found. Loading {prev_saved_rframe}")
 else:
     log("Using new reference frame.")
@@ -89,9 +93,6 @@ msg_occu = ""
 msg_car = ""
 last_car = ""
 last_occu = ""
-
-data_output_fd = get_value_from_tag(sys_config, "system-output-location")
-csv_file_location = get_value_from_tag(sys_config, "csv-file-location")
 
 csv_write_timer = time.time()
 


### PR DESCRIPTION
Added a stub in the main CSV file for system restart (failure/error). If this stub appears, we skip the line and the 3 lines after it to account for the system restart when a car is in the space. If a system restart occurs and a car is in the space, originally there would be a jump in the data, but now that it is fixed.